### PR TITLE
Fixed hyperxmp package import conflicting with hyperref package import in WSU.sty

### DIFF
--- a/WSUThesisTemplate.tex
+++ b/WSUThesisTemplate.tex
@@ -47,8 +47,6 @@
 \newcommand{\pdfsubject}{a short paraphrase of your title or focus of your thesis}
 \newcommand{\pdfkeywords}{keyword 1, keyword 2, keyword 3, keyword 4}
 \newcommand{\yearcomplete}{2013}
-% set pdf file info
-\usepackage{hyperxmp} % used to set pdf property info with \hypersetup command
 
 %-----------------------------------------------------------------------
 %  Thesis Advisor, Department Chair, Dean of Graduate Studies
@@ -100,6 +98,9 @@
 
 % title sheet
 \usepackage{WSU}
+% set pdf file info
+\usepackage{hyperxmp} % used to set pdf property info with \hypersetup command
+
 \hypersetup{
                      pdfauthor={\authorfull},
                      pdftitle={\thesistitle},


### PR DESCRIPTION
This PR addresses an error when building the PDF from source related to package imports. 

This contribution was made possible when Owen discovered hyperxmp now depends on hyperref and the correct place to import hyperxmp is immediately after importing WSU.sty which finishes by importing hyperref.